### PR TITLE
Get the plugin going

### DIFF
--- a/AddCtECitationStyle.inc.php
+++ b/AddCtECitationStyle.inc.php
@@ -28,7 +28,7 @@ class AddCtECitationStyle extends GenericPlugin {
 			'id' => 'contributions-to-entomology',
 			'title' => 'Contributions to Entomology',
 			'isEnabled' => true,
-			'useCsl' => '/srv/www/htdocs/journals/beitraege_entomology/plugins/generic/addCtECitationStyle/citationStyle.csl',
+			'useCsl' => Core::getBaseDir() . '/' . $this->getPluginPath() . '/contribEntomol.csl',
 		);
 	}
 

--- a/AddCtECitationStyle.inc.php
+++ b/AddCtECitationStyle.inc.php
@@ -3,43 +3,43 @@
 import('lib.pkp.classes.plugins.GenericPlugin');
 
 class AddCtECitationStyle extends GenericPlugin {
-    /**
-     * Hook into citation style
-     */
-    public function init() {
-	HookRegistry::register('CitationStyleLanguage::citationStyleDefaults', array($this, 'addCSLStyle'));
-    }
+	/**
+	 * Hook into citation style
+	 */
+	public function init() {
+		HookRegistry::register('CitationStyleLanguage::citationStyleDefaults', array($this, 'addCSLStyle'));
+	}
 
-    /**
-     * Add a CSL style to the list of default styles
-     *
-     * @param string $hookname
-     * @param array $args [$defaults, CitationStyleLanguagePlugin]
-     */
-    public function addCSLStyle($hookName, $args) {
- 	$defaults =& $args[0];
+	/**
+	 * Add a CSL style to the list of default styles
+	 *
+	 * @param string $hookname
+	 * @param array $args [$defaults, CitationStyleLanguagePlugin]
+	 */
+	public function addCSLStyle($hookName, $args) {
+		$defaults =& $args[0];
 
-	$defaults[] = array(
-		'id' => 'contributions-to-entomology',
-		'title' => 'Contributions to Entomology',
-		'isEnabled' => true,
-		'useCsl' => '/srv/www/htdocs/journals/beitraege_entomology/plugins/generic/addCtECitationStyle/citationStyle.csl',
-	);
-    }
-    
-    /**
-     * @copydoc Plugin::getDisplayName()
-     */
-     function getDisplayName() {
-  	return ('Contributions to Entomology Citation Style');
-     }
-     
-     /**
-      * @copydoc Plugin::getDescription()
-      */
-      function getDescription() {
-	return ('Add the CtE citation style to the Citation Style Language.');
-      }
+		$defaults[] = array(
+			'id' => 'contributions-to-entomology',
+			'title' => 'Contributions to Entomology',
+			'isEnabled' => true,
+			'useCsl' => '/srv/www/htdocs/journals/beitraege_entomology/plugins/generic/addCtECitationStyle/citationStyle.csl',
+		);
+	}
+
+	/**
+	 * @copydoc Plugin::getDisplayName()
+	 */
+	function getDisplayName() {
+		return ('Contributions to Entomology Citation Style');
+	}
+
+	/**
+	 * @copydoc Plugin::getDescription()
+	 */
+	function getDescription() {
+		return ('Add the CtE citation style to the Citation Style Language.');
+	}
 }
 
 ?>

--- a/AddCtECitationStyle.inc.php
+++ b/AddCtECitationStyle.inc.php
@@ -4,10 +4,15 @@ import('lib.pkp.classes.plugins.GenericPlugin');
 
 class AddCtECitationStyle extends GenericPlugin {
 	/**
-	 * Hook into citation style
+	 * @copydoc Plugin::register()
 	 */
-	public function init() {
-		HookRegistry::register('CitationStyleLanguage::citationStyleDefaults', array($this, 'addCSLStyle'));
+	public function register($category, $path, $mainContextId = null) {
+		$success = parent::register($category, $path, $mainContextId);
+		if (!Config::getVar('general', 'installed') || defined('RUNNING_UPGRADE')) return $success;
+		if ($success && $this->getEnabled($mainContextId)) {
+			HookRegistry::register('CitationStyleLanguage::citationStyleDefaults', array($this, 'addCSLStyle'));
+		}
+		return $success;
 	}
 
 	/**


### PR DESCRIPTION
The following changes should get the plugin working for you. After these changes are merged, you should:

- Enable the plugin from Settings > Website > Plugins.
- Go to Citatiion Style Language plugin settings on the same screen (you may need to refresh the page, maybe not).
- Enable the new style under Additional Citation Formats. (You may want to make it primary too.)
- Test it out on a published article.

I needed to make two changes to get this working:

1. The hook should actually go into a register method, which plugins use to identify themselves. The `init()` method is unique to theme plugins, and just hides some of the complexity of the `register()` method.
2. I modified the path to the CSL file so that it should work wherever the plugin is installed.