### PR TITLE
Value of <application> has to be identical to the plugin's folder name

### DIFF
--- a/version.xml
+++ b/version.xml
@@ -6,7 +6,7 @@
   -->
 
 <version>
-    <application>addCtECitationStyle</application>
+    <application>CitationPlugin</application>
     <type>plugins.generic</type>
     <release>1.0.0.0</release>
     <date>2018-02-15</date>


### PR DESCRIPTION
Some modification to make it work with OJS 3.3 (not tested with earlier versions.)